### PR TITLE
in email error messages, print the last 40 lines of output

### DIFF
--- a/lib/Logger.py
+++ b/lib/Logger.py
@@ -107,7 +107,8 @@ class Logger:
 
     log = Log.objects.filter(build = self.build)
     if limit is not None:
-      log = log[:limit]
+      # get the last lines
+      log = log[-limit:]
     output = ""
     for row in log:
        output += row.line


### PR DESCRIPTION
not the first rows of output
fixes #204